### PR TITLE
Upgrade version to 2022.04.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # defaults file
 ---
 
-rstudio_connect_version: "2021.12.1"
+rstudio_connect_version: "2022.04.2"
 rstudio_connect_version_short: "{{ rstudio_connect_version | regex_replace('.[^.]*$', '') }}"
 
 rstudio_connect_install: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,6 @@
 # meta file
 ---
 galaxy_info:
-  namespace: appsilon
   role_name: rstudio_connect
   author: shmileee
   company: Appsilon

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,7 +4,7 @@ dependency:
 driver:
   name: docker
 platforms:
-  - name: instance
+  - name: instance-rsc
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:


### PR DESCRIPTION
## Changes description

This PR:
- upgrades default RSC version to 2022.04.2
- fixes `ansible-lint`

For more information regarding the changes, see official [release notes](https://docs.rstudio.com/connect/news/#rstudio-connect-2022042) for RStudio Connect.