### PR TITLE
fix(lint): added missing spaces for filters

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,6 @@ rstudio_connect_config:
   Authentication:
     Provider: "password"
   'RPackageRepository "CRAN"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/{{ ansible_lsb.codename|lower }}/latest
+    URL: https://packagemanager.rstudio.com/cran/__linux__/{{ ansible_lsb.codename | lower }}/latest
   'RPackageRepository "RSPM"':
-    URL: https://packagemanager.rstudio.com/cran/__linux__/{{ ansible_lsb.codename|lower }}/latest
+    URL: https://packagemanager.rstudio.com/cran/__linux__/{{ ansible_lsb.codename | lower }}/latest

--- a/vars/_focal.yml
+++ b/vars/_focal.yml
@@ -4,4 +4,4 @@ rstudio_connect_download_url: "https://cdn.rstudio.com/connect/{{ rstudio_connec
 
 rstudio_connect_pro_drivers_download_url: "https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_{{ rstudio_connect_pro_drivers_version }}_{{ rstudio_connect_machine_map[ansible_machine] }}.deb"
 
-r_download_url: "https://cdn.rstudio.com/r/ubuntu-{{ ansible_lsb.release|replace('.','') }}/pkgs"
+r_download_url: "https://cdn.rstudio.com/r/ubuntu-{{ ansible_lsb.release | replace('.','') }}/pkgs"


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Changes description

Small fix of linting errors, which occur during running CI workflow ([example run #121](https://github.com/Appsilon/ansible-rstudio-connect/runs/7532426229?check_suite_focus=true)).

Ansible-lint added a rule for checking if there are spaces before and after filters. This change was introduced in version [6.3.0](https://github.com/ansible/ansible-lint/releases/tag/v6.3.0).

CI workflow always uses the latest version, so the errors appeared after the mentioned version of `ansible-lint` was released.

I just added missing spaces and linted locally the code with `ansible-lint` in the latest version (6.4.0). Should be ok now.