### PR TITLE
feat: configure Python versions with variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Set up (the latest version of) [RStudio Connect](https://www.rstudio.com/product
 * `rstudio_connect_config`: A map of maps containing RStudio Connect configuration. Gets converted into Golang's configuration file (GCFG) and is writted on down to `rstudio-connect.gcfg`. See [default](./defaults/main.yml) for an example.
 * `rstudio_connect_config_override` [default: `""`]: If you know what you're doing, you can override whole `rstudio-connect.gcfg` config.
 * `rstudio_connect_license`: If specified, RStudio Connect will attempt to activate the supplied license key.
+* `rstudio_connect_enable_python` [default: `false`]: If specified, the configuration file will contain Python section with Enabled set to `true`.
+* `rstudio_connect_python_executables` [default: `[]`]: List of paths to Python executables (e.g. `[/opt/python/3.10.6/bin/python3]`). Additional Python versions can be installed with [ansible-python-install role](https://github.com/Appsilon/ansible-python-install).
 
 For the rest of the default variables, see
 [./defaults/main.yml](./defaults/main.yml).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,6 @@ rstudio_connect_config:
     URL: https://packagemanager.rstudio.com/cran/__linux__/{{ ansible_lsb.codename | lower }}/latest
   'RPackageRepository "RSPM"':
     URL: https://packagemanager.rstudio.com/cran/__linux__/{{ ansible_lsb.codename | lower }}/latest
+
+rstudio_connect_enable_python: false
+rstudio_connect_python_executables: []

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 # handlers file
 ---
-- name: restart rstudio-connect
+- name: Restart rstudio-connect
   ansible.builtin.service:
     name: rstudio-connect
     state: restarted

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,7 +3,7 @@
   hosts: all
   become: true
   pre_tasks:
-    - name: include vars
+    - name: Include vars
       ansible.builtin.include_vars: "{{ playbook_dir }}/../../tests/vars/main.yml"
   roles:
     - ../../../

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: configure | write encryption key to file
+- name: Configure | write encryption key to file
   ansible.builtin.copy:
     content: "{{ rstudio_encryption_key | trim }}"
     dest: "{{ rstudio_connect_encryption_key_location }}"
@@ -13,7 +13,7 @@
   tags:
     - rstudio-connect-encryption-key
 
-- name: configure | create (SSO metadata xml) file
+- name: Configure | create (SSO metadata xml) file
   ansible.builtin.copy:
     content: "{{ rstudio_connect_sso_saml_metadata_content_b64_encoded | b64decode }}"
     dest: "{{ rstudio_connect_sso_saml_metadata_file_path }}"
@@ -24,42 +24,42 @@
     - rstudio_connect_sso_saml_metadata_content_b64_encoded|d()
     - rstudio_connect_sso_saml_metadata_file_path|d()
 
-- name: link systemd default environment file to /etc/environment
+- name: Link systemd default environment file to /etc/environment
   ansible.builtin.file:
     src: /etc/environment
     dest: /etc/default/rstudio-connect
     state: link
     owner: root
     group: root
-  notify: restart rstudio-connect
+  notify: Restart rstudio-connect
   tags:
     - rstudio-connect-configure-environment-file
 
-- name: configure | update (server) configuration file
+- name: Configure | update (server) configuration file
   ansible.builtin.template:
     src: etc/rstudio-connect/rstudio-connect.gcfg.j2
     dest: /etc/rstudio-connect/rstudio-connect.gcfg
     owner: root
     group: root
     mode: 0644
-  notify: restart rstudio-connect
+  notify: Restart rstudio-connect
   tags:
     - rstudio-connect-configure-server
 
-- name: configure | update (server) migration file
+- name: Configure | update (server) migration file
   ansible.builtin.template:
     src: etc/rstudio-connect/rstudio-connect-migration.gcfg.j2
     dest: /etc/rstudio-connect/rstudio-connect-migration.gcfg
     owner: root
     group: root
     mode: 0644
-  notify: restart rstudio-connect
+  notify: Restart rstudio-connect
   tags:
     - rstudio-connect-configure-migration
 
-- name: license activation (offline)
+- name: License activation (offline)
   block:
-    - name: license activation (offline) | upload key file
+    - name: License activation (offline) | upload key file
       ansible.builtin.copy:
         content: "{{ rstudio_connect_license_offline_key_b64_encoded | b64decode }}"
         dest: "/etc/rstudio-connect/activation-key.lic"
@@ -67,17 +67,17 @@
         group: root
         mode: 0600
 
-    - name: license activation (offline) | activate using key file  # noqa no-changed-when
+    - name: License activation (offline) | activate using key file  # noqa no-changed-when
       ansible.builtin.shell: |
         /opt/rstudio-connect/bin/license-manager activate-file /etc/rstudio-connect/activation-key.lic
-  when: rstudio_connect_license_offline_key_b64_encoded|d()
-  notify: restart rstudio-connect
+  when: rstudio_connect_license_offline_key_b64_encoded | d()
+  notify: Restart rstudio-connect
   no_log: true
 
-- name: license activation (online) | activate key
+- name: License activation (online) | activate key
   ansible.builtin.shell: |
     /opt/rstudio-connect/bin/license-manager activate {{ rstudio_connect_license }}
-  notify: restart rstudio-connect
+  notify: Restart rstudio-connect
   register: license_output
-  when: rstudio_connect_license|d()
+  when: rstudio_connect_license | d()
   no_log: true

--- a/tasks/install-drivers.yml
+++ b/tasks/install-drivers.yml
@@ -1,13 +1,13 @@
 ---
 
-- name: install pro-drivers | install dependencies
+- name: Install pro-drivers | install dependencies
   ansible.builtin.apt:
     name: "{{ rstudio_connect_pro_drivers_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
 
-- name: install pro-drivers | download deb
+- name: Install pro-drivers | download deb
   ansible.builtin.get_url:
     url: "{{ rstudio_connect_pro_drivers_download_url }}"
     dest: "{{ rstudio_connect_downloads_path }}/rstudio-drivers_{{ rstudio_connect_pro_drivers_version }}_{{ rstudio_connect_machine_map[ansible_machine] }}.deb"
@@ -15,11 +15,11 @@
     owner: root
     group: root
 
-- name: install pro-drivers | install deb
+- name: Install pro-drivers | install deb
   ansible.builtin.apt:
     deb: "{{ rstudio_connect_downloads_path }}/rstudio-drivers_{{ rstudio_connect_pro_drivers_version }}_{{ rstudio_connect_machine_map[ansible_machine] }}.deb"
 
-- name: configure pro-drivers | create odbcinst.ini
+- name: Configure pro-drivers | create odbcinst.ini
   ansible.builtin.copy:
     src: /opt/rstudio-drivers/odbcinst.ini.sample
     dest: /etc/odbcinst.ini

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 # tasks file
 ---
-- name: install | dependencies
+- name: Install | dependencies
   ansible.builtin.apt:
     name: "{{ rstudio_connect_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
@@ -9,14 +9,14 @@
   tags:
     - rstudio-connect-install-dependencies
 
-- name: install | additional
+- name: Install | additional
   ansible.builtin.apt:
     name: "{{ rstudio_connect_install }}"
     state: "{{ apt_install_state | default('latest') }}"
   tags:
     - rstudio-connect-install-additional
 
-- name: install | create (download) directory
+- name: Install | create (download) directory
   ansible.builtin.file:
     path: "{{ rstudio_connect_downloads_path }}"
     state: directory
@@ -27,7 +27,7 @@
     - rstudio-connect-install-download
     - rstudio-connect-install-download-directory
 
-- name: install | download deb
+- name: Install | download deb
   ansible.builtin.command: >
     curl --silent --show-error --fail --location
     {{ rstudio_connect_download_url }}
@@ -39,7 +39,7 @@
     - rstudio-connect-install-download
     - rstudio-connect-install-download-deb
 
-- name: install | install deb
+- name: Install | install deb
   ansible.builtin.apt:
     deb: "{{ rstudio_connect_downloads_path }}/rstudio-connect-{{ rstudio_connect_version }}-{{ rstudio_connect_machine_map[ansible_machine] }}.deb"
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 
-- name: include variables
+- name: Include variables
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "_{{ ansible_distribution_release }}.yml"
@@ -17,7 +17,7 @@
     - configuration
     - rstudio-connect
     - rstudio-connect-install
-  notify: restart rstudio-connect
+  notify: Restart rstudio-connect
 
 - include: configure.yml
   tags:
@@ -28,7 +28,7 @@
 - include: install-drivers.yml
   when: rstudio_connect_pro_drivers_install
 
-- name: start and enable service
+- name: Start and enable service
   ansible.builtin.service:
     name: rstudio-connect
     state: "{{ service_default_state | default('started') }}"

--- a/templates/etc/rstudio-connect/rstudio-connect.gcfg.j2
+++ b/templates/etc/rstudio-connect/rstudio-connect.gcfg.j2
@@ -7,3 +7,11 @@
 {% from "macros/gcfg_encode_macro.j2" import gcfg_encode with context -%}
 {{ gcfg_encode(rstudio_connect_config) }}
 {% endif %}
+
+{% if rstudio_connect_enable_python %}
+[Python]
+Enabled = true
+{% for exec in rstudio_connect_python_executables %}
+Executable = {{ exec }}
+{% endfor %}
+{% endif %}

--- a/tests/tasks/post.yml
+++ b/tests/tasks/post.yml
@@ -1,19 +1,8 @@
 # post test file
 ---
-- name: install test dependencies
-  ansible.builtin.apt:
-    name:
-      - wget
-    state: "{{ apt_install_state | default('latest') }}"
-
-- name: test rstudio-connect installation
-  ansible.builtin.shell: >
-    wget http://localhost:3939 -O /dev/null -S --quiet 2>&1
-    | grep -q '402 Payment Required'
-    && (echo 'Availability test: pass' && exit 0)
-    || (echo 'Availability test: fail' && exit 1)
-  args:
-    warn: false
-  changed_when: false
-  tags:
-    - skip_ansible_lint
+- name: Test rstudio-connect installation
+  ansible.builtin.uri:
+    url: http://localhost:3939/__ping__
+    status_code:
+      - 200
+      - 402

--- a/vars/_focal.yml
+++ b/vars/_focal.yml
@@ -4,4 +4,4 @@ rstudio_connect_download_url: "https://cdn.rstudio.com/connect/{{ rstudio_connec
 
 rstudio_connect_pro_drivers_download_url: "https://cdn.rstudio.com/drivers/7C152C12/installer/rstudio-drivers_{{ rstudio_connect_pro_drivers_version }}_{{ rstudio_connect_machine_map[ansible_machine] }}.deb"
 
-r_download_url: "https://cdn.rstudio.com/r/ubuntu-{{ ansible_lsb.release | replace('.','') }}/pkgs"
+r_download_url: "https://cdn.rstudio.com/r/ubuntu-{{ ansible_lsb.release | replace('.', '') }}/pkgs"


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Changes description

Changes allow to configure multiple Python versions within Connect - the section in the configuration is generated with variables and template.
Without changes in the config template it wouldn't be possible to configure more than 1 version of Python. With `rstudio_connect_config` it's possible to pass configuration, however it's a map, so it's forbidden to define multiple `Executable` keys.