### PR TITLE
chore: bump default version to 2023.06.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Set up (the latest version of) [RStudio Connect](https://www.rstudio.com/product
 
 ## Role Variables
 
-* `rstudio_connect_version` [default: `2023.01.1`]: Version to install
+* `rstudio_connect_version` [default: `2023.06.0`]: Version to install
 * `rstudio_connect_install` [default: `[]`]: Additional packages to install (e.g. `r-base`)
 * `rstudio_connect_www_port` [default: `3939`]: The port you want RStudio Connect to listen on
 * `rstudio_connect_config`: A map of maps containing RStudio Connect configuration. Gets converted into Golang's configuration file (GCFG) and is writted on down to `rstudio-connect.gcfg`. See [default](./defaults/main.yml) for an example.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 # defaults file
 ---
 
-rstudio_connect_version: "2023.01.1"
+rstudio_connect_version: "2023.06.0"
 rstudio_connect_version_short: "{{ rstudio_connect_version | regex_replace('.[^.]*$', '') }}"
 
 rstudio_connect_install: []


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #

## Changes description

Bumping the default version to 2023.06.0
