### PR TITLE
feat(rhel9): add RHEL9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install test dependencies
         run: pip install ansible-lint[community,yamllint]
@@ -40,9 +40,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        scenario: [default, with-python]
-        distro: [ubuntu2004, ubuntu2204]
-        ansible-version: ['>=2.11.5']
+        scenario: [default, with-python, default]
+        distro: [ubuntu2004, ubuntu2204, ubi9]
+        platform: [instance-rsc, instance-rsc, instance-rh]
 
     steps:
       - name: Check out the codebase
@@ -53,17 +53,18 @@ jobs:
       - name: Set up Python 3
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: '3.12'
 
       - name: Install test dependencies
-        run: pip install 'ansible${{ matrix.ansible-version }}' molecule molecule-plugins[docker] docker
+        run: pip install -r requirements.txt
 
       - name: Run Molecule tests
         run: |
-          molecule test -s "${{ matrix.scenario }}"
+          molecule test -s "${{ matrix.scenario }} --platform-name ${MOLECULE_PLATFORM:-instance-rsc"
         env:
           ANSIBLE_FORCE_COLOR: '1'
           ANSIBLE_VERBOSITY: '2'
           MOLECULE_DEBUG: '1'
           MOLECULE_DISTRO: "${{ matrix.distro }}"
+          MOLECULE_PLATFORM: "${{ matrix.platform }}"
           PY_COLORS: '1'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -14,6 +14,12 @@ platforms:
     cgroupns_mode: host
     pre_build_image: true
     platform: linux/amd64
+  - <<: *instance
+    name: instance-rh
+    image: "registry.access.redhat.com/${MOLECULE_DISTRO:-ubi9}/ubi-init"
+    command: "/usr/sbin/init"
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
 provisioner:
   name: ansible
   playbooks:

--- a/tasks/redhat/main.yml
+++ b/tasks/redhat/main.yml
@@ -1,7 +1,7 @@
 # tasks file
 ---
 - name: Install | dependencies
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ rstudio_connect_dependencies }}"
     state: "{{ package_install_state | default('latest') }}"
     update_cache: true
@@ -9,7 +9,7 @@
     - rstudio-connect-install-dependencies
 
 - name: Install | additional
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ rstudio_connect_install }}"
     state: "{{ package_install_state | default('latest') }}"
   tags:
@@ -33,7 +33,7 @@
     mode: '0755'
 
 - name: Install | install rpm
-  ansible.builtin.yum:
+  ansible.builtin.dnf:
     name: "{{ rstudio_connect_downloads_path }}/rstudio-connect-{{ rstudio_connect_version }}.rpm"
     disable_gpg_check: true
   tags:

--- a/vars/_redhat-9.yml
+++ b/vars/_redhat-9.yml
@@ -1,0 +1,3 @@
+# vars file
+---
+rstudio_connect_download_url: "https://cdn.rstudio.com/connect/{{ rstudio_connect_version_short }}/rstudio-connect-{{ rstudio_connect_version }}.el9.x86_64.rpm"


### PR DESCRIPTION

Issue #68

## Description
Adding RHEL9 support and tests.

## Definition of Done
- [x] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [x] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)

Changes for now:
- Testing with UBI9 image
- Swapping FQCN to use `dnf` instead of `yum`
- Forcing Python 3.12
- Using `requirements.txt` in CI
- Adding another platform execution to Molecule

Notes:
- Not bumping drivers version yet